### PR TITLE
minor fixes: struct member types, typo

### DIFF
--- a/src/bind_group.zig
+++ b/src/bind_group.zig
@@ -1,4 +1,3 @@
-// zig fmt: off
 const _chained_struct = @import("chained_struct.zig");
 const ChainedStruct = _chained_struct.ChainedStruct;
 const SType = _chained_struct.SType;

--- a/src/bind_group.zig
+++ b/src/bind_group.zig
@@ -1,3 +1,4 @@
+// zig fmt: off
 const _chained_struct = @import("chained_struct.zig");
 const ChainedStruct = _chained_struct.ChainedStruct;
 const SType = _chained_struct.SType;
@@ -79,9 +80,9 @@ pub const BindGroupEntryExtras = extern struct {
     chain: ChainedStruct = ChainedStruct {
         .s_type = SType.bind_group_entry_extras,
     },
-    buffers: ?[*]const Buffer,
+    buffers: ?[*]const *Buffer,
     buffer_count: usize = 0,
-    samplers: ?[*]const Sampler,
+    samplers: ?[*]const *Sampler,
     sampler_count: usize = 0,
     texture_views: ?[*]const TextureView,
     texture_view_count: usize = 0,

--- a/src/command_encoder.zig
+++ b/src/command_encoder.zig
@@ -149,7 +149,7 @@ pub const ColorAttachment = extern struct {
     view: ?*TextureView,
     depth_slice: u32 = WGPU_DEPTH_SLICE_UNDEFINED,
     resolve_target: ?*TextureView = null,
-    loap_op: LoadOp = LoadOp.clear,
+    load_op: LoadOp = LoadOp.clear,
     store_op: StoreOp = StoreOp.store,
     clear_value: Color = Color {},
 };

--- a/src/pipeline.zig
+++ b/src/pipeline.zig
@@ -1,4 +1,3 @@
-// zig fmt: off
 const _chained_struct = @import("chained_struct.zig");
 const ChainedStruct = _chained_struct.ChainedStruct;
 const SType = _chained_struct.SType;

--- a/src/pipeline.zig
+++ b/src/pipeline.zig
@@ -1,3 +1,4 @@
+// zig fmt: off
 const _chained_struct = @import("chained_struct.zig");
 const ChainedStruct = _chained_struct.ChainedStruct;
 const SType = _chained_struct.SType;
@@ -34,7 +35,7 @@ pub const PipelineLayoutDescriptor = extern struct {
     next_in_chain: ?*const ChainedStruct = null,
     label: ?[*:0]const u8 = null,
     bind_group_layout_count: usize,
-    bind_group_layouts: [*]const BindGroupLayout,
+    bind_group_layouts: [*]const *BindGroupLayout,
 
     pub inline fn withPushConstantRanges(
         self: PipelineLayoutDescriptor,


### PR DESCRIPTION
I encountered an error during the creation of the PipelineLayoutDescriptor struct:
`error: unknown-length pointer to opaque not allowed
bind_group_layouts: [*]const BindGroupLayout,`

Changing the member to an array of pointers fixed the issue.

I also found a typo in the ColorAttachment struct ("loap_op" instead of "load_op")