### PR TITLE
Fix function signature for wgpuSurfaceCapabilitiesFreeMembers binding

### DIFF
--- a/src/surface.zig
+++ b/src/surface.zig
@@ -212,9 +212,9 @@ pub const SurfaceConfiguration = extern struct {
 };
 
 pub const SurfaceCapabilitiesProcs = struct {
-    pub const FreeMembers = *const fn(*SurfaceCapabilities) callconv(.C) void;
+    pub const FreeMembers = *const fn(SurfaceCapabilities) callconv(.C) void;
 };
-extern fn wgpuSurfaceCapabilitiesFreeMembers(surface_capabilities: *SurfaceCapabilities) void;
+extern fn wgpuSurfaceCapabilitiesFreeMembers(surface_capabilities: SurfaceCapabilities) void;
 pub const SurfaceCapabilities = extern struct {
     next_in_chain: ?*ChainedStructOut = null,
     usages: TextureUsageFlags,
@@ -225,7 +225,7 @@ pub const SurfaceCapabilities = extern struct {
     alpha_mode_count: usize,
     alpha_modes: [*]const CompositeAlphaMode,
 
-    pub inline fn FreeMembers(self: *SurfaceCapabilities) void {
+    pub inline fn freeMembers(self: SurfaceCapabilities) void {
         wgpuSurfaceCapabilitiesFreeMembers(self);
     }
 };


### PR DESCRIPTION
This should fix #15 ; since SurfaceCapaabilities isn't an opaque struct it gets passed in by value rather than by reference, and the naming should be consistent with `AdapterInfo.freeMembers()`.

I have a Windows example that uses SurfaceCapabilities; I want to test this on that just to be sure, then I'll merge.