### PR TITLE
Make building bindgroup layout entries easier.

### DIFF
--- a/src/bind_group.zig
+++ b/src/bind_group.zig
@@ -32,10 +32,10 @@ pub const BindGroupLayoutEntry = extern struct {
     next_in_chain: ?*const ChainedStruct = null,
     binding: u32,
     visibility: ShaderStageFlags,
-    buffer: BufferBindingLayout,
-    sampler: SamplerBindingLayout,
-    texture: TextureBindingLayout,
-    storage_texture: StorageTextureBindingLayout,
+    buffer: BufferBindingLayout = .{},
+    sampler: SamplerBindingLayout = .{},
+    texture: TextureBindingLayout = .{},
+    storage_texture: StorageTextureBindingLayout = .{},
 
     pub inline fn withCount(self: BindGroupLayoutEntry, count: u32) BindGroupLayoutEntry {
         var bgle = self;


### PR DESCRIPTION
It is tedious to fill out all of these fields when making BindGroupLayoutEntrys, usually, if not always, you are just filling out one of these.