### PR TITLE
Rename Reference to AddRef.

### DIFF
--- a/src/adapter.zig
+++ b/src/adapter.zig
@@ -136,9 +136,6 @@ pub const Adapter = opaque{
     pub inline fn requestDevice(self: *Adapter, descriptor: ?*const DeviceDescriptor, callback: AdapterRequestDeviceCallback, userdata: ?*anyopaque) void {
         wgpuAdapterRequestDevice(self, descriptor, callback, userdata);
     }
-    pub inline fn reference(self: *Adapter) void {
-        addRef(self);
-    }
     pub inline fn addRef(self: *Adapter) void {
         wgpuAdapterAddRef(self);
     }

--- a/src/adapter.zig
+++ b/src/adapter.zig
@@ -94,7 +94,7 @@ pub const AdapterProcs = struct {
     pub const GetInfo = *const fn(Adapter, *AdapterInfo) callconv(.C) void;
     pub const HasFeature = *const fn(Adapter, FeatureName) callconv(.C) WGPUBool;
     pub const RequestDevice = *const fn(Adapter, ?*const DeviceDescriptor, AdapterRequestDeviceCallback, ?*anyopaque) callconv(.C) void;
-    pub const Reference = *const fn(Adapter) callconv(.C) void;
+    pub const AddRef = *const fn(Adapter) callconv(.C) void;
     pub const Release = *const fn(Adapter) callconv(.C) void;
 };
 
@@ -103,7 +103,7 @@ extern fn wgpuAdapterGetLimits(adapter: *Adapter, limits: *SupportedLimits) WGPU
 extern fn wgpuAdapterGetInfo(adapter: *Adapter, info: *AdapterInfo) void;
 extern fn wgpuAdapterHasFeature(adapter: *Adapter, feature: FeatureName) WGPUBool;
 extern fn wgpuAdapterRequestDevice(adapter: *Adapter, descriptor: ?*const DeviceDescriptor, callback: AdapterRequestDeviceCallback, userdata: ?*anyopaque) void;
-extern fn wgpuAdapterReference(adapter: *Adapter) void;
+extern fn wgpuAdapterAddRef(adapter: *Adapter) void;
 extern fn wgpuAdapterRelease(adapter: *Adapter) void;
 
 pub const Adapter = opaque{
@@ -137,7 +137,10 @@ pub const Adapter = opaque{
         wgpuAdapterRequestDevice(self, descriptor, callback, userdata);
     }
     pub inline fn reference(self: *Adapter) void {
-        wgpuAdapterReference(self);
+        addRef(self);
+    }
+    pub inline fn addRef(self: *Adapter) void {
+        wgpuAdapterAddRef(self);
     }
     pub inline fn release(self: *Adapter) void {
         wgpuAdapterRelease(self);

--- a/src/bind_group.zig
+++ b/src/bind_group.zig
@@ -55,12 +55,12 @@ pub const BindGroupLayoutDescriptor = extern struct {
 
 pub const BindGroupLayoutProcs = struct {
     pub const SetLabel = *const fn(*BindGroupLayout, ?[*:0]const u8) callconv(.C) void;
-    pub const Reference = *const fn(*BindGroupLayout) callconv(.C) void;
+    pub const AddRef = *const fn(*BindGroupLayout) callconv(.C) void;
     pub const Release = *const fn(*BindGroupLayout) callconv(.C) void;
 };
 
 extern fn wgpuBindGroupLayoutSetLabel(bind_group_layout: *BindGroupLayout, label: ?[*:0]const u8) void;
-extern fn wgpuBindGroupLayoutReference(bind_group_layout: *BindGroupLayout) void;
+extern fn wgpuBindGroupLayoutAddRef(bind_group_layout: *BindGroupLayout) void;
 extern fn wgpuBindGroupLayoutRelease(bind_group_layout: *BindGroupLayout) void;
 
 pub const BindGroupLayout = opaque {
@@ -68,7 +68,10 @@ pub const BindGroupLayout = opaque {
         wgpuBindGroupLayoutSetLabel(self, label);
     }
     pub inline fn reference(self: *BindGroupLayout) void {
-        wgpuBindGroupLayoutReference(self);
+        addRef(self);
+    }
+    pub inline fn addRef(self: *BindGroupLayout) void {
+        wgpuBindGroupLayoutAddRef(self);
     }
     pub inline fn release(self: *BindGroupLayout) void {
         wgpuBindGroupLayoutRelease(self);

--- a/src/bind_group.zig
+++ b/src/bind_group.zig
@@ -113,17 +113,20 @@ pub const BindGroupDescriptor = extern struct {
 
 pub const BindGroupProcs = struct {
     pub const SetLabel = *const fn(*BindGroup, ?[*:0]const u8) callconv(.C) void;
-    pub const Reference = *const fn(*BindGroup) callconv(.C) void;
+    pub const AddRef = *const fn(*BindGroup) callconv(.C) void;
     pub const Release = *const fn(*BindGroup) callconv(.C) void;
 };
 
 extern fn wgpuBindGroupSetLabel(bind_group: *BindGroup, label: ?[*:0]const u8) void;
-extern fn wgpuBindGroupReference(bind_group: *BindGroup) void;
+extern fn wgpuBindGroupAddRef(bind_group: *BindGroup) void;
 extern fn wgpuBindGroupRelease(bind_group: *BindGroup) void;
 
 pub const BindGroup = opaque {
     pub inline fn setLabel(self: *BindGroup, label: ?[*:0]const u8) void {
         wgpuBindGroupSetLabel(self, label);
+    }
+    pub inline fn addRef(self: *BindGroup) void {
+        wgpuBindGroupAddRef(self);
     }
     pub inline fn release(self: *BindGroup) void {
         wgpuBindGroupRelease(self);

--- a/src/bind_group.zig
+++ b/src/bind_group.zig
@@ -67,9 +67,6 @@ pub const BindGroupLayout = opaque {
     pub inline fn setLabel(self: *BindGroupLayout, label: ?[*:0]const u8) void {
         wgpuBindGroupLayoutSetLabel(self, label);
     }
-    pub inline fn reference(self: *BindGroupLayout) void {
-        addRef(self);
-    }
     pub inline fn addRef(self: *BindGroupLayout) void {
         wgpuBindGroupLayoutAddRef(self);
     }
@@ -127,9 +124,6 @@ extern fn wgpuBindGroupRelease(bind_group: *BindGroup) void;
 pub const BindGroup = opaque {
     pub inline fn setLabel(self: *BindGroup, label: ?[*:0]const u8) void {
         wgpuBindGroupSetLabel(self, label);
-    }
-    pub inline fn reference(self: *BindGroup) void {
-        wgpuBindGroupReference(self);
     }
     pub inline fn release(self: *BindGroup) void {
         wgpuBindGroupRelease(self);

--- a/src/buffer.zig
+++ b/src/buffer.zig
@@ -85,7 +85,7 @@ pub const BufferProcs = struct {
     pub const MapAsync = *const fn(*Buffer, MapModeFlags, usize, usize, BufferMapAsyncCallback, ?*anyopaque) callconv(.C) void;
     pub const SetLabel = *const fn(*Buffer, ?[*:0]const u8) callconv(.C) void;
     pub const Unmap = *const fn(*Buffer) callconv(.C) void;
-    pub const Reference = *const fn(*Buffer) callconv(.C) void;
+    pub const AddRef = *const fn(*Buffer) callconv(.C) void;
     pub const Release = *const fn(*Buffer) callconv(.C) void;
 };
 
@@ -98,7 +98,7 @@ extern fn wgpuBufferGetUsage(buffer: *Buffer) BufferUsageFlags;
 extern fn wgpuBufferMapAsync(buffer: *Buffer, mode: MapModeFlags, offset: usize, size: usize, callback: BufferMapAsyncCallback, userdata: ?*anyopaque) void;
 extern fn wgpuBufferSetLabel(buffer: *Buffer, label: ?[*:0]const u8) void;
 extern fn wgpuBufferUnmap(buffer: *Buffer) void;
-extern fn wgpuBufferReference(buffer: *Buffer) void;
+extern fn wgpuBufferAddRef(buffer: *Buffer) void;
 extern fn wgpuBufferRelease(buffer: *Buffer) void;
 
 pub const Buffer = opaque {
@@ -137,7 +137,10 @@ pub const Buffer = opaque {
         wgpuBufferUnmap(self);
     }
     pub inline fn reference(self: *Buffer) void {
-        wgpuBufferReference(self);
+        addRef(self);
+    }
+    pub inline fn addRef(self: *Buffer) void {
+        wgpuBufferAddRef(self);
     }
     pub inline fn release(self: *Buffer) void {
         wgpuBufferRelease(self);

--- a/src/buffer.zig
+++ b/src/buffer.zig
@@ -136,9 +136,6 @@ pub const Buffer = opaque {
     pub inline fn unmap(self: *Buffer) void {
         wgpuBufferUnmap(self);
     }
-    pub inline fn reference(self: *Buffer) void {
-        addRef(self);
-    }
     pub inline fn addRef(self: *Buffer) void {
         wgpuBufferAddRef(self);
     }

--- a/src/command_encoder.zig
+++ b/src/command_encoder.zig
@@ -113,9 +113,6 @@ pub const ComputePassEncoder = opaque {
     pub inline fn setPipeline(self: *ComputePassEncoder, pipeline: *ComputePipeline) void {
         wgpuComputePassEncoderSetPipeline(self, pipeline);
     }
-    pub inline fn reference(self: *ComputePassEncoder) void {
-        addRef(self);
-    }
     pub inline fn addRef(self: *ComputePassEncoder) void {
         wgpuComputePassEncoderAddRef(self);
     }
@@ -336,9 +333,6 @@ pub const RenderPassEncoder = opaque {
     pub inline fn setViewport(self: *RenderPassEncoder, x: f32, y: f32, width: f32, height: f32, min_depth: f32, max_depth: f32) void {
         wgpuRenderPassEncoderSetViewport(self, x, y, width, height, min_depth, max_depth);
     }
-    pub inline fn reference(self: *RenderPassEncoder) void {
-        addRef(self);
-    }
     pub inline fn addRef(self: *RenderPassEncoder) void {
         wgpuRenderPassEncoderAddRef(self);
     }
@@ -391,9 +385,6 @@ extern fn wgpuCommandBufferRelease(command_buffer: *CommandBuffer) void;
 pub const CommandBuffer = opaque {
     pub inline fn setLabel(self: *CommandBuffer, label: ?[*:0]const u8) void {
         wgpuCommandBufferSetLabel(self, label);
-    }
-    pub inline fn reference(self: *CommandBuffer) void {
-        addRef(self);
     }
     pub inline fn addRef(self: *CommandBuffer) void {
         wgpuCommandBufferAddRef(self);
@@ -481,9 +472,6 @@ pub const CommandEncoder = opaque {
     }
     pub inline fn writeTimestamp(self: *CommandEncoder, query_set: *QuerySet, query_index: u32) void {
         wgpuCommandEncoderWriteTimestamp(self, query_set, query_index);
-    }
-    pub inline fn reference(self: *CommandEncoder) void {
-        addRef(self);
     }
     pub inline fn addRef(self: *CommandEncoder) void {
         wgpuCommandEncoderAddRef(self);

--- a/src/command_encoder.zig
+++ b/src/command_encoder.zig
@@ -57,7 +57,7 @@ const ComputePassEncoderProcs = struct {
     pub const SetBindGroup = *const fn(*ComputePassEncoder, u32, *BindGroup, usize, ?[*]const u32) callconv(.C) void;
     pub const SetLabel = *const fn(*ComputePassEncoder, ?[*:0]const u8) callconv(.C) void;
     pub const SetPipeline = *const fn(*ComputePassEncoder, *ComputePipeline) callconv(.C) void;
-    pub const Reference = *const fn(*ComputePassEncoder) callconv(.C) void;
+    pub const AddRef = *const fn(*ComputePassEncoder) callconv(.C) void;
     pub const Release = *const fn(*ComputePassEncoder) callconv(.C) void;
 
     // wgpu-native procs?
@@ -76,7 +76,7 @@ extern fn wgpuComputePassEncoderPushDebugGroup(compute_pass_encoder: *ComputePas
 extern fn wgpuComputePassEncoderSetBindGroup(compute_pass_encoder: *ComputePassEncoder, group_index: u32, group: *BindGroup, dynamic_offset_count: usize, dynamic_offsets: ?[*]const u32) void;
 extern fn wgpuComputePassEncoderSetLabel(compute_pass_encoder: *ComputePassEncoder, label: ?[*:0]const u8) void;
 extern fn wgpuComputePassEncoderSetPipeline(compute_pass_encoder: *ComputePassEncoder, pipeline: *ComputePipeline) void;
-extern fn wgpuComputePassEncoderReference(compute_pass_encoder: *ComputePassEncoder) void;
+extern fn wgpuComputePassEncoderAddRef(compute_pass_encoder: *ComputePassEncoder) void;
 extern fn wgpuComputePassEncoderRelease(compute_pass_encoder: *ComputePassEncoder) void;
 
 // wgpu-native
@@ -114,7 +114,10 @@ pub const ComputePassEncoder = opaque {
         wgpuComputePassEncoderSetPipeline(self, pipeline);
     }
     pub inline fn reference(self: *ComputePassEncoder) void {
-        wgpuComputePassEncoderReference(self);
+        addRef(self);
+    }
+    pub inline fn addRef(self: *ComputePassEncoder) void {
+        wgpuComputePassEncoderAddRef(self);
     }
     pub inline fn release(self: *ComputePassEncoder) void {
         wgpuComputePassEncoderRelease(self);
@@ -225,7 +228,7 @@ pub const RenderPassEncoderProcs = struct {
     pub const SetStencilReference = *const fn(*RenderPassEncoder, u32) callconv(.C) void;
     pub const SetVertexBuffer = *const fn(*RenderPassEncoder, u32, *Buffer, u64, u64) callconv(.C) void;
     pub const SetViewport = *const fn(*RenderPassEncoder, f32, f32, f32, f32, f32, f32) callconv(.C) void;
-    pub const Reference = *const fn(*RenderPassEncoder) callconv(.C) void;
+    pub const AddRef = *const fn(*RenderPassEncoder) callconv(.C) void;
     pub const Release = *const fn(*RenderPassEncoder) callconv(.C) void;
 
     // wgpu-native procs?
@@ -259,7 +262,7 @@ extern fn wgpuRenderPassEncoderSetScissorRect(render_pass_encoder: *RenderPassEn
 extern fn wgpuRenderPassEncoderSetStencilReference(render_pass_encoder: *RenderPassEncoder, stencil_reference: u32) void;
 extern fn wgpuRenderPassEncoderSetVertexBuffer(render_pass_encoder: *RenderPassEncoder, slot: u32, buffer: *Buffer, offset: u64, size: u64) void;
 extern fn wgpuRenderPassEncoderSetViewport(render_pass_encoder: *RenderPassEncoder, x: f32, y: f32, width: f32, height: f32, min_depth: f32, max_depth: f32) void;
-extern fn wgpuRenderPassEncoderReference(render_pass_encoder: *RenderPassEncoder) void;
+extern fn wgpuRenderPassEncoderAddRef(render_pass_encoder: *RenderPassEncoder) void;
 extern fn wgpuRenderPassEncoderRelease(render_pass_encoder: *RenderPassEncoder) void;
 
 // wgpu-native
@@ -334,7 +337,10 @@ pub const RenderPassEncoder = opaque {
         wgpuRenderPassEncoderSetViewport(self, x, y, width, height, min_depth, max_depth);
     }
     pub inline fn reference(self: *RenderPassEncoder) void {
-        wgpuRenderPassEncoderReference(self);
+        addRef(self);
+    }
+    pub inline fn addRef(self: *RenderPassEncoder) void {
+        wgpuRenderPassEncoderAddRef(self);
     }
     pub inline fn release(self: *RenderPassEncoder) void {
         wgpuRenderPassEncoderRelease(self);
@@ -374,12 +380,12 @@ pub const CommandBufferDescriptor = extern struct {
 
 pub const CommandBufferProcs = struct {
     pub const SetLabel = *const fn(*CommandBuffer, ?[*:0]const u8) callconv(.C) void;
-    pub const Reference = *const fn(*CommandBuffer) callconv(.C) void;
+    pub const AddRef = *const fn(*CommandBuffer) callconv(.C) void;
     pub const Release = *const fn(*CommandBuffer) callconv(.C) void;
 };
 
 extern fn wgpuCommandBufferSetLabel(command_buffer: *CommandBuffer, label: ?[*:0]const u8) void;
-extern fn wgpuCommandBufferReference(command_buffer: *CommandBuffer) void;
+extern fn wgpuCommandBufferAddRef(command_buffer: *CommandBuffer) void;
 extern fn wgpuCommandBufferRelease(command_buffer: *CommandBuffer) void;
 
 pub const CommandBuffer = opaque {
@@ -387,7 +393,10 @@ pub const CommandBuffer = opaque {
         wgpuCommandBufferSetLabel(self, label);
     }
     pub inline fn reference(self: *CommandBuffer) void {
-        wgpuCommandBufferReference(self);
+        addRef(self);
+    }
+    pub inline fn addRef(self: *CommandBuffer) void {
+        wgpuCommandBufferAddRef(self);
     }
     pub inline fn release(self: *CommandBuffer) void {
         wgpuCommandBufferRelease(self);
@@ -409,7 +418,7 @@ pub const CommandEncoderProcs = struct {
     pub const ResolveQuerySet = *const fn(*CommandEncoder, *QuerySet, u32, u32, *Buffer, u64) callconv(.C) void;
     pub const SetLabel = *const fn(*CommandEncoder, ?[*:0]const u8) callconv(.C) void;
     pub const WriteTimestamp = *const fn(*CommandEncoder, *QuerySet, u32) callconv(.C) void;
-    pub const Reference = *const fn(*CommandEncoder) callconv(.C) void;
+    pub const AddRef = *const fn(*CommandEncoder) callconv(.C) void;
     pub const Release = *const fn(*CommandEncoder) callconv(.C) void;
 };
 
@@ -427,7 +436,7 @@ extern fn wgpuCommandEncoderPushDebugGroup(command_encoder: *CommandEncoder, gro
 extern fn wgpuCommandEncoderResolveQuerySet(command_encoder: *CommandEncoder, query_set: *QuerySet, first_query: u32, query_count: u32, destination: *Buffer, destination_offset: u64) void;
 extern fn wgpuCommandEncoderSetLabel(command_encoder: *CommandEncoder, label: ?[*:0]const u8) void;
 extern fn wgpuCommandEncoderWriteTimestamp(command_encoder: *CommandEncoder, query_set: *QuerySet, query_index: u32) void;
-extern fn wgpuCommandEncoderReference(command_encoder: *CommandEncoder) void;
+extern fn wgpuCommandEncoderAddRef(command_encoder: *CommandEncoder) void;
 extern fn wgpuCommandEncoderRelease(command_encoder: *CommandEncoder) void;
 
 pub const CommandEncoder = opaque {
@@ -474,7 +483,10 @@ pub const CommandEncoder = opaque {
         wgpuCommandEncoderWriteTimestamp(self, query_set, query_index);
     }
     pub inline fn reference(self: *CommandEncoder) void {
-        wgpuCommandEncoderReference(self);
+        addRef(self);
+    }
+    pub inline fn addRef(self: *CommandEncoder) void {
+        wgpuCommandEncoderAddRef(self);
     }
     pub inline fn release(self: *CommandEncoder) void {
         wgpuCommandEncoderRelease(self);

--- a/src/device.zig
+++ b/src/device.zig
@@ -165,7 +165,7 @@ pub const DeviceProcs = struct {
     pub const PopErrorScope = *const fn(*Device, ErrorCallback, ?*anyopaque) callconv(.C) void;
     pub const PushErrorScope = *const fn(*Device, ErrorFilter) callconv(.C) void;
     pub const SetLabel = *const fn(*Device, ?[*:0]const u8) callconv(.C) void;
-    pub const Reference = *const fn(*Device) callconv(.C) void;
+    pub const AddRef = *const fn(*Device) callconv(.C) void;
     pub const Release = *const fn(*Device) callconv(.C) void;
 
     // wgpu-native procs?
@@ -195,7 +195,7 @@ extern fn wgpuDeviceHasFeature(device: *Device, feature: FeatureName) WGPUBool;
 extern fn wgpuDevicePopErrorScope(device: *Device, callback: ErrorCallback, userdata: ?*anyopaque) void;
 extern fn wgpuDevicePushErrorScope(device: *Device, filter: ErrorFilter) void;
 extern fn wgpuDeviceSetLabel(device: *Device, label: ?[*:0]const u8) void;
-extern fn wgpuDeviceReference(device: *Device) void;
+extern fn wgpuDeviceAddRef(device: *Device) void;
 extern fn wgpuDeviceRelease(device: *Device) void;
 
 // wgpu-native
@@ -283,7 +283,10 @@ pub const Device = opaque {
         wgpuDeviceSetLabel(self, label);
     }
     pub inline fn reference(self: *Device) void {
-        wgpuDeviceReference(self);
+        addRef(self);
+    }
+    pub inline fn addRef(self: *Device) void {
+        wgpuDeviceAddRef(self);
     }
     pub inline fn release(self: *Device) void {
         wgpuDeviceRelease(self);

--- a/src/device.zig
+++ b/src/device.zig
@@ -282,9 +282,6 @@ pub const Device = opaque {
     pub inline fn setLabel(self: *Device, label: ?[*:0]const u8) void {
         wgpuDeviceSetLabel(self, label);
     }
-    pub inline fn reference(self: *Device) void {
-        addRef(self);
-    }
     pub inline fn addRef(self: *Device) void {
         wgpuDeviceAddRef(self);
     }

--- a/src/instance.zig
+++ b/src/instance.zig
@@ -181,11 +181,6 @@ pub const Instance = opaque {
     pub inline fn requestAdapter(self: *Instance, options: ?*const RequestAdapterOptions, callback: InstanceRequestAdapterCallback, userdata: ?*anyopaque) void {
         wgpuInstanceRequestAdapter(self, options, callback, userdata);
     }
-    // Dunno what this does, but it appears in webgpu.h so I guess it's important?
-    pub inline fn reference(self: *Instance) void {
-        // TODO: Find out WTF wgpuInstanceAddRef does.
-        addRef(self);
-    }
 
     pub inline fn addRef(self: *Instance) void {
         // TODO: Find out WTF wgpuInstanceAddRef does.

--- a/src/instance.zig
+++ b/src/instance.zig
@@ -89,7 +89,7 @@ pub const InstanceProcs = struct {
     pub const HasWGSLLanguageFeature = *const fn(*Instance, WGSLFeatureName) WGPUBool;
     pub const ProcessEvents = *const fn(*Instance) callconv(.C) void;
     pub const RequestAdapter = *const fn(*Instance, ?*const RequestAdapterOptions, InstanceRequestAdapterCallback, ?*anyopaque) callconv(.C) void;
-    pub const InstanceReference = *const fn(*Instance) callconv(.C) void;
+    pub const InstanceAddRef = *const fn(*Instance) callconv(.C) void;
     pub const InstanceRelease = *const fn(*Instance) callconv(.C) void;
 
     // wgpu-native procs?
@@ -102,7 +102,7 @@ extern fn wgpuInstanceCreateSurface(instance: *Instance, descriptor: *const Surf
 extern fn wgpuInstanceHasWGSLLanguageFeature(instance: *Instance, feature: WGSLFeatureName) WGPUBool;
 extern fn wgpuInstanceProcessEvents(instance: *Instance) void;
 extern fn wgpuInstanceRequestAdapter(instance: *Instance, options: ?*const RequestAdapterOptions, callback: InstanceRequestAdapterCallback, userdata: ?*anyopaque) void;
-extern fn wgpuInstanceReference(instance: *Instance) void;
+extern fn wgpuInstanceAddRef(instance: *Instance) void;
 extern fn wgpuInstanceRelease(instance: *Instance) void;
 
 pub const RegistryReport = extern struct {
@@ -181,12 +181,17 @@ pub const Instance = opaque {
     pub inline fn requestAdapter(self: *Instance, options: ?*const RequestAdapterOptions, callback: InstanceRequestAdapterCallback, userdata: ?*anyopaque) void {
         wgpuInstanceRequestAdapter(self, options, callback, userdata);
     }
-
     // Dunno what this does, but it appears in webgpu.h so I guess it's important?
     pub inline fn reference(self: *Instance) void {
-        // TODO: Find out WTF wgpuInstanceReference does.
-        wgpuInstanceReference(self);
+        // TODO: Find out WTF wgpuInstanceAddRef does.
+        addRef(self);
     }
+
+    pub inline fn addRef(self: *Instance) void {
+        // TODO: Find out WTF wgpuInstanceAddRef does.
+        wgpuInstanceAddRef(self);
+    }
+
 
     pub inline fn release(self: *Instance) void {
         wgpuInstanceRelease(self);

--- a/src/pipeline.zig
+++ b/src/pipeline.zig
@@ -52,12 +52,12 @@ pub const PipelineLayoutDescriptor = extern struct {
 
 pub const PipelineLayoutProcs = struct {
     pub const SetLabel = *const fn(*PipelineLayout, ?[*:0]const u8) callconv(.C) void;
-    pub const Reference = *const fn(*PipelineLayout) callconv(.C) void;
+    pub const AddRef = *const fn(*PipelineLayout) callconv(.C) void;
     pub const Release = *const fn(*PipelineLayout) callconv(.C) void;
 };
 
 extern fn wgpuPipelineLayoutSetLabel(pipeline_layout: *PipelineLayout, label: ?[*:0]const u8) void;
-extern fn wgpuPipelineLayoutReference(pipeline_layout: *PipelineLayout) void;
+extern fn wgpuPipelineLayoutAddRef(pipeline_layout: *PipelineLayout) void;
 extern fn wgpuPipelineLayoutRelease(pipeline_layout: *PipelineLayout) void;
 
 pub const PipelineLayout = opaque {
@@ -65,7 +65,10 @@ pub const PipelineLayout = opaque {
         wgpuPipelineLayoutSetLabel(self, label);
     }
     pub inline fn reference(self: *PipelineLayout) void {
-        wgpuPipelineLayoutReference(self);
+        addRef(self);
+    }
+    pub inline fn addRef(self: *PipelineLayout) void {
+        wgpuPipelineLayoutAddRef(self);
     }
     pub inline fn release(self: *PipelineLayout) void {
         wgpuPipelineLayoutRelease(self);
@@ -113,13 +116,13 @@ pub const DeviceCreateComputePipelineAsyncCallback = *const fn(
 pub const ComputePipelineProcs = struct {
     pub const GetBindGroupLayout = *const fn(*ComputePipeline, u32) callconv(.C) ?*BindGroupLayout;
     pub const SetLabel = *const fn(*ComputePipeline, ?[*:0]const u8) callconv(.C) void;
-    pub const Reference = *const fn(*ComputePipeline) callconv(.C) void;
+    pub const AddRef = *const fn(*ComputePipeline) callconv(.C) void;
     pub const Release = *const fn(*ComputePipeline) callconv(.C) void;
 };
 
 extern fn wgpuComputePipelineGetBindGroupLayout(compute_pipeline: *ComputePipeline, group_index: u32) ?*BindGroupLayout;
 extern fn wgpuComputePipelineSetLabel(compute_pipeline: *ComputePipeline, label: ?[*:0]const u8) void;
-extern fn wgpuComputePipelineReference(compute_pipeline: *ComputePipeline) void;
+extern fn wgpuComputePipelineAddRef(compute_pipeline: *ComputePipeline) void;
 extern fn wgpuComputePipelineRelease(compute_pipeline: *ComputePipeline) void;
 
 pub const ComputePipeline = opaque {
@@ -130,7 +133,10 @@ pub const ComputePipeline = opaque {
         wgpuComputePipelineSetLabel(self, label);
     }
     pub inline fn reference(self: *ComputePipeline) void {
-        wgpuComputePipelineReference(self);
+        addRef(self);
+    }
+    pub inline fn addRef(self: *ComputePipeline) void {
+        wgpuComputePipelineAddRef(self);
     }
     pub inline fn release(self: *ComputePipeline) void {
         wgpuComputePipelineRelease(self);
@@ -396,13 +402,13 @@ pub const RenderPipelineDescriptor = extern struct {
 pub const RenderPipelineProcs = struct {
     pub const GetBindGroupLayout = *const fn(*RenderPipeline, u32) callconv(.C) ?*BindGroupLayout;
     pub const SetLabel = *const fn(*RenderPipeline, ?[*:0]const u8) callconv(.C) void;
-    pub const Reference = *const fn(*RenderPipeline) callconv(.C) void;
+    pub const AddRef = *const fn(*RenderPipeline) callconv(.C) void;
     pub const Release = *const fn(*RenderPipeline) callconv(.C) void;
 };
 
 extern fn wgpuRenderPipelineGetBindGroupLayout(render_pipeline: *RenderPipeline, group_index: u32) ?*BindGroupLayout;
 extern fn wgpuRenderPipelineSetLabel(render_pipeline: *RenderPipeline, label: ?[*:0]const u8) void;
-extern fn wgpuRenderPipelineReference(render_pipeline: *RenderPipeline) void;
+extern fn wgpuRenderPipelineAddRef(render_pipeline: *RenderPipeline) void;
 extern fn wgpuRenderPipelineRelease(render_pipeline: *RenderPipeline) void;
 
 pub const RenderPipeline = opaque {
@@ -413,7 +419,10 @@ pub const RenderPipeline = opaque {
         wgpuRenderPipelineSetLabel(self, label);
     }
     pub inline fn reference(self: *RenderPipeline) void {
-        wgpuRenderPipelineReference(self);
+        addRef(self);
+    }
+    pub inline fn addRef(self: *RenderPipeline) void {
+        wgpuRenderPipelineAddRef(self);
     }
     pub inline fn release(self: *RenderPipeline) void {
         wgpuRenderPipelineRelease(self);

--- a/src/pipeline.zig
+++ b/src/pipeline.zig
@@ -64,9 +64,6 @@ pub const PipelineLayout = opaque {
     pub inline fn setLabel(self: *PipelineLayout, label: ?[*:0]const u8) void {
         wgpuPipelineLayoutSetLabel(self, label);
     }
-    pub inline fn reference(self: *PipelineLayout) void {
-        addRef(self);
-    }
     pub inline fn addRef(self: *PipelineLayout) void {
         wgpuPipelineLayoutAddRef(self);
     }
@@ -131,9 +128,6 @@ pub const ComputePipeline = opaque {
     }
     pub inline fn setLabel(self: *ComputePipeline, label: ?[*:0]const u8) void {
         wgpuComputePipelineSetLabel(self, label);
-    }
-    pub inline fn reference(self: *ComputePipeline) void {
-        addRef(self);
     }
     pub inline fn addRef(self: *ComputePipeline) void {
         wgpuComputePipelineAddRef(self);
@@ -417,9 +411,6 @@ pub const RenderPipeline = opaque {
     }
     pub inline fn setLabel(self: *RenderPipeline, label: ?[*:0]const u8) void {
         wgpuRenderPipelineSetLabel(self, label);
-    }
-    pub inline fn reference(self: *RenderPipeline) void {
-        addRef(self);
     }
     pub inline fn addRef(self: *RenderPipeline) void {
         wgpuRenderPipelineAddRef(self);

--- a/src/query_set.zig
+++ b/src/query_set.zig
@@ -75,9 +75,6 @@ pub const QuerySet = opaque {
     pub inline fn setLabel(self: *QuerySet, label: ?[*:0]const u8) void {
         wgpuQuerySetSetLabel(self, label);
     }
-    pub inline fn reference(self: *QuerySet) void {
-        addRef(self);
-    }
     pub inline fn addRef(self: *QuerySet) void {
         wgpuQuerySetAddRef(self);
     }

--- a/src/query_set.zig
+++ b/src/query_set.zig
@@ -51,7 +51,7 @@ pub const QuerySetProcs = struct {
     pub const GetCount = *const fn(*QuerySet) callconv(.C) u32;
     pub const GetType = *const fn(*QuerySet) callconv(.C) QueryType;
     pub const SetLabel = *const fn(*QuerySet, ?[*:0]const u8) callconv(.C) void;
-    pub const Reference = *const fn(*QuerySet) callconv(.C) void;
+    pub const AddRef = *const fn(*QuerySet) callconv(.C) void;
     pub const Release = *const fn(*QuerySet) callconv(.C) void;
 };
 
@@ -59,7 +59,7 @@ extern fn wgpuQuerySetDestroy(query_set: *QuerySet) void;
 extern fn wgpuQuerySetGetCount(query_set: *QuerySet) u32;
 extern fn wgpuQuerySetGetType(query_set: *QuerySet) QueryType;
 extern fn wgpuQuerySetSetLabel(query_set: *QuerySet, label: ?[*:0]const u8) void;
-extern fn wgpuQuerySetReference(query_set: *QuerySet) void;
+extern fn wgpuQuerySetAddRef(query_set: *QuerySet) void;
 extern fn wgpuQuerySetRelease(query_set: *QuerySet) void;
 
 pub const QuerySet = opaque {
@@ -76,7 +76,10 @@ pub const QuerySet = opaque {
         wgpuQuerySetSetLabel(self, label);
     }
     pub inline fn reference(self: *QuerySet) void {
-        wgpuQuerySetReference(self);
+        addRef(self);
+    }
+    pub inline fn addRef(self: *QuerySet) void {
+        wgpuQuerySetAddRef(self);
     }
     pub inline fn release(self: *QuerySet) void {
         wgpuQuerySetRelease(self);

--- a/src/queue.zig
+++ b/src/queue.zig
@@ -63,9 +63,6 @@ pub const Queue = opaque {
     pub inline fn writeTexture(self: *Queue, destination: *const ImageCopyTexture, data: *const anyopaque, data_size: usize, data_layout: *const TextureDataLayout, write_size: *const Extent3D) void {
         wgpuQueueWriteTexture(self, destination, data, data_size, data_layout, write_size);
     }
-    pub inline fn reference(self: *Queue) void {
-        addRef(self);
-    }
     pub inline fn addRef(self: *Queue) void {
         wgpuQueueAddRef(self);
     }

--- a/src/queue.zig
+++ b/src/queue.zig
@@ -29,7 +29,7 @@ pub const QueueProcs = struct {
     pub const Submit = *const fn(*Queue, usize, [*]const *const CommandBuffer) callconv(.C) void;
     pub const WriteBuffer = *const fn(*Queue, Buffer, u64, *const anyopaque, usize) callconv(.C) void;
     pub const WriteTexture = *const fn(*Queue, *const ImageCopyTexture, *const anyopaque, usize, *const TextureDataLayout, *const Extent3D) callconv(.C) void;
-    pub const Reference = *const fn(*Queue) callconv(.C) void;
+    pub const AddRef = *const fn(*Queue) callconv(.C) void;
     pub const Release = *const fn(*Queue) callconv(.C) void;
 
     // wgpu-native procs?
@@ -41,7 +41,7 @@ extern fn wgpuQueueSetLabel(queue: *Queue, label: ?[*:0]const u8) void;
 extern fn wgpuQueueSubmit(queue: *Queue, command_count: usize, commands: [*]const *const CommandBuffer) void;
 extern fn wgpuQueueWriteBuffer(queue: *Queue, buffer: *Buffer, buffer_offset: u64, data: *const anyopaque, size: usize) void;
 extern fn wgpuQueueWriteTexture(queue: *Queue, destination: *const ImageCopyTexture, data: *const anyopaque, data_size: usize, data_layout: *const TextureDataLayout, write_size: *const Extent3D) void;
-extern fn wgpuQueueReference(queue: *Queue) void;
+extern fn wgpuQueueAddRef(queue: *Queue) void;
 extern fn wgpuQueueRelease(queue: *Queue) void;
 
 // wgpu-native
@@ -64,7 +64,10 @@ pub const Queue = opaque {
         wgpuQueueWriteTexture(self, destination, data, data_size, data_layout, write_size);
     }
     pub inline fn reference(self: *Queue) void {
-        wgpuQueueReference(self);
+        addRef(self);
+    }
+    pub inline fn addRef(self: *Queue) void {
+        wgpuQueueAddRef(self);
     }
     pub inline fn release(self: *Queue) void {
         wgpuQueueRelease(self);

--- a/src/render_bundle.zig
+++ b/src/render_bundle.zig
@@ -101,9 +101,6 @@ pub const RenderBundleEncoder = opaque {
     pub inline fn setVertexBuffer(self: *RenderBundleEncoder, slot: u32, buffer: *Buffer, offset: u64, size: u64) void {
         wgpuRenderBundleEncoderSetVertexBuffer(self, slot, buffer, offset, size);
     }
-    pub inline fn reference(self: *RenderBundleEncoder) void {
-        addRef(self);
-    }
     pub inline fn addRef(self: *RenderBundleEncoder) void {
         wgpuRenderBundleEncoderAddRef(self);
     }
@@ -135,9 +132,6 @@ extern fn wgpuRenderBundleRelease(render_bundle: *RenderBundle) void;
 pub const RenderBundle = opaque {
     pub inline fn setLabel(self: *RenderBundle, label: ?[*:0]const u8) void {
         wgpuRenderBundleSetLabel(self, label);
-    }
-    pub inline fn reference(self: *RenderBundle) void {
-        addRef(self);
     }
     pub inline fn addRef(self: *RenderBundle) void {
         wgpuRenderBundleAddRef(self);

--- a/src/render_bundle.zig
+++ b/src/render_bundle.zig
@@ -34,7 +34,7 @@ pub const RenderBundleEncoderProcs = struct {
     pub const SetLabel = *const fn(*RenderBundleEncoder, ?[*:0]const u8) callconv(.C) void;
     pub const SetPipeline = *const fn(*RenderBundleEncoder, *RenderPipeline) callconv(.C) void;
     pub const SetVertexBuffer = *const fn(*RenderBundleEncoder, u32, *Buffer, u64, u64) callconv(.C) void;
-    pub const Reference = *const fn(*RenderBundleEncoder) callconv(.C) void;
+    pub const AddRef = *const fn(*RenderBundleEncoder) callconv(.C) void;
     pub const Release = *const fn(*RenderBundleEncoder) callconv(.C) void;
 
     // wgpu-native procs?
@@ -54,7 +54,7 @@ extern fn wgpuRenderBundleEncoderSetIndexBuffer(render_bundle_encoder: *RenderBu
 extern fn wgpuRenderBundleEncoderSetLabel(render_bundle_encoder: *RenderBundleEncoder, label: ?[*:0]const u8) void;
 extern fn wgpuRenderBundleEncoderSetPipeline(render_bundle_encoder: *RenderBundleEncoder, pipeline: *RenderPipeline) void;
 extern fn wgpuRenderBundleEncoderSetVertexBuffer(render_bundle_encoder: *RenderBundleEncoder, slot: u32, buffer: *Buffer, offset: u64, size: u64) void;
-extern fn wgpuRenderBundleEncoderReference(render_bundle_encoder: *RenderBundleEncoder) void;
+extern fn wgpuRenderBundleEncoderAddRef(render_bundle_encoder: *RenderBundleEncoder) void;
 extern fn wgpuRenderBundleEncoderRelease(render_bundle_encoder: *RenderBundleEncoder) void;
 
 // wgpu-native
@@ -102,7 +102,10 @@ pub const RenderBundleEncoder = opaque {
         wgpuRenderBundleEncoderSetVertexBuffer(self, slot, buffer, offset, size);
     }
     pub inline fn reference(self: *RenderBundleEncoder) void {
-        wgpuRenderBundleEncoderReference(self);
+        addRef(self);
+    }
+    pub inline fn addRef(self: *RenderBundleEncoder) void {
+        wgpuRenderBundleEncoderAddRef(self);
     }
     pub inline fn release(self: *RenderBundleEncoder) void {
         wgpuRenderBundleEncoderRelease(self);
@@ -121,12 +124,12 @@ pub const RenderBundleDescriptor = extern struct {
 
 pub const RenderBundleProcs = struct {
     pub const SetLabel = *const fn(*RenderBundle, ?[*:0]const u8) callconv(.C) void;
-    pub const Reference = *const fn(*RenderBundle) callconv(.C) void;
+    pub const AddRef = *const fn(*RenderBundle) callconv(.C) void;
     pub const Release = *const fn(*RenderBundle) callconv(.C) void;
 };
 
 extern fn wgpuRenderBundleSetLabel(render_bundle: *RenderBundle, label: ?[*:0]const u8) void;
-extern fn wgpuRenderBundleReference(render_bundle: *RenderBundle) void;
+extern fn wgpuRenderBundleAddRef(render_bundle: *RenderBundle) void;
 extern fn wgpuRenderBundleRelease(render_bundle: *RenderBundle) void;
 
 pub const RenderBundle = opaque {
@@ -134,7 +137,10 @@ pub const RenderBundle = opaque {
         wgpuRenderBundleSetLabel(self, label);
     }
     pub inline fn reference(self: *RenderBundle) void {
-        wgpuRenderBundleReference(self);
+        addRef(self);
+    }
+    pub inline fn addRef(self: *RenderBundle) void {
+        wgpuRenderBundleAddRef(self);
     }
     pub inline fn release(self: *RenderBundle) void {
         wgpuRenderBundleRelease(self);

--- a/src/sampler.zig
+++ b/src/sampler.zig
@@ -58,9 +58,6 @@ pub const Sampler = opaque {
     pub inline fn setLabel(self: *Sampler, label: ?[*:0]const u8) void {
         wgpuSamplerSetLabel(self, label);
     }
-    pub inline fn reference(self: *Sampler) void {
-        addRef(self);
-    }
     pub inline fn addRef(self: *Sampler) void {
         wgpuSamplerAddRef(self);
     }

--- a/src/sampler.zig
+++ b/src/sampler.zig
@@ -46,12 +46,12 @@ pub const SamplerDescriptor = extern struct {
 
 pub const SamplerProcs = struct {
     pub const SetLabel = *const fn(*Sampler, ?[*:0]const u8) callconv(.C) void;
-    pub const Reference = *const fn(*Sampler) callconv(.C) void;
+    pub const AddRef = *const fn(*Sampler) callconv(.C) void;
     pub const Release = *const fn(*Sampler) callconv(.C) void;
 };
 
 extern fn wgpuSamplerSetLabel(sampler: *Sampler, label: ?[*:0]const u8) void;
-extern fn wgpuSamplerReference(sampler: *Sampler) void;
+extern fn wgpuSamplerAddRef(sampler: *Sampler) void;
 extern fn wgpuSamplerRelease(sampler: *Sampler) void;
 
 pub const Sampler = opaque {
@@ -59,7 +59,10 @@ pub const Sampler = opaque {
         wgpuSamplerSetLabel(self, label);
     }
     pub inline fn reference(self: *Sampler) void {
-        wgpuSamplerReference(self);
+        addRef(self);
+    }
+    pub inline fn addRef(self: *Sampler) void {
+        wgpuSamplerAddRef(self);
     }
     pub inline fn release(self: *Sampler) void {
         wgpuSamplerRelease(self);

--- a/src/shader.zig
+++ b/src/shader.zig
@@ -164,13 +164,13 @@ pub const ShaderModuleGetCompilationInfoCallback = *const fn(status: Compilation
 pub const ShaderModuleProcs = struct {
     pub const GetCompilationInfo = *const fn(*ShaderModule, ShaderModuleGetCompilationInfoCallback, ?*anyopaque) callconv(.C) void;
     pub const SetLabel = *const fn(*ShaderModule, ?[*:0]const u8) callconv(.C) void;
-    pub const Reference = *const fn(*ShaderModule) callconv(.C) void;
+    pub const AddRef = *const fn(*ShaderModule) callconv(.C) void;
     pub const Release = *const fn(*ShaderModule) callconv(.C) void;
 };
 
 extern fn wgpuShaderModuleGetCompilationInfo(shader_module: *ShaderModule, callback: ShaderModuleGetCompilationInfoCallback, userdata: ?*anyopaque) void;
 extern fn wgpuShaderModuleSetLabel(shader_module: *ShaderModule, label: ?[*:0]const u8) void;
-extern fn wgpuShaderModuleReference(shader_module: *ShaderModule) void;
+extern fn wgpuShaderModuleAddRef(shader_module: *ShaderModule) void;
 extern fn wgpuShaderModuleRelease(shader_module: *ShaderModule) void;
 
 pub const ShaderModule = opaque {
@@ -181,7 +181,10 @@ pub const ShaderModule = opaque {
         wgpuShaderModuleSetLabel(self, label);
     }
     pub inline fn reference(self: *ShaderModule) void {
-        wgpuShaderModuleReference(self);
+        wgpuShaderModuleAddRef(self);
+    }
+    pub inline fn addRef(self: *ShaderModule) void {
+        wgpuShaderModuleAddRef(self);
     }
     pub inline fn release(self: *ShaderModule) void {
         wgpuShaderModuleRelease(self);

--- a/src/shader.zig
+++ b/src/shader.zig
@@ -180,9 +180,6 @@ pub const ShaderModule = opaque {
     pub inline fn setLabel(self: *ShaderModule, label: ?[*:0]const u8) void {
         wgpuShaderModuleSetLabel(self, label);
     }
-    pub inline fn reference(self: *ShaderModule) void {
-        wgpuShaderModuleAddRef(self);
-    }
     pub inline fn addRef(self: *ShaderModule) void {
         wgpuShaderModuleAddRef(self);
     }

--- a/src/surface.zig
+++ b/src/surface.zig
@@ -252,7 +252,7 @@ pub const SurfaceProcs = struct {
     pub const Present = *const fn(*Surface) callconv(.C) void;
     pub const SetLabel = *const fn(*Surface, ?[*:0]const u8) void;
     pub const Unconfigure = *const fn(*Surface) callconv(.C) void;
-    pub const Reference = *const fn(*Surface) callconv(.C) void;
+    pub const AddRef = *const fn(*Surface) callconv(.C) void;
     pub const Release = *const fn(*Surface) callconv(.C) void;
 };
 
@@ -262,7 +262,7 @@ extern fn wgpuSurfaceGetCurrentTexture(surface: *Surface, surface_texture: *Surf
 extern fn wgpuSurfacePresent(surface: *Surface) void;
 extern fn wgpuSurfaceSetLabel(surface: *Surface, label: ?[*:0]const u8) void;
 extern fn wgpuSurfaceUnconfigure(surface: *Surface) void;
-extern fn wgpuSurfaceReference(surface: *Surface) void;
+extern fn wgpuSurfaceAddRef(surface: *Surface) void;
 extern fn wgpuSurfaceRelease(surface: *Surface) void;
 
 pub const Surface = opaque {
@@ -285,7 +285,10 @@ pub const Surface = opaque {
         wgpuSurfaceUnconfigure(self);
     }
     pub inline fn reference(self: *Surface) void {
-        wgpuSurfaceReference(self);
+        addRef(self);
+    }
+    pub inline fn addRef(self: *Surface) void {
+        wgpuSurfaceAddRef(self);
     }
     pub inline fn release(self: *Surface) void {
         wgpuSurfaceRelease(self);

--- a/src/surface.zig
+++ b/src/surface.zig
@@ -284,9 +284,6 @@ pub const Surface = opaque {
     pub inline fn unconfigure(self: *Surface) void {
         wgpuSurfaceUnconfigure(self);
     }
-    pub inline fn reference(self: *Surface) void {
-        addRef(self);
-    }
     pub inline fn addRef(self: *Surface) void {
         wgpuSurfaceAddRef(self);
     }

--- a/src/texture.zig
+++ b/src/texture.zig
@@ -151,12 +151,12 @@ pub const TextureViewDescriptor = extern struct {
 
 pub const TextureViewProcs = struct {
     pub const SetLabel = *const fn(*TextureView, ?[*:0]const u8) callconv(.C) void;
-    pub const Reference = *const fn(*TextureView) callconv(.C) void;
+    pub const AddRef = *const fn(*TextureView) callconv(.C) void;
     pub const Release = *const fn(*TextureView) callconv(.C) void;
 };
 
 extern fn wgpuTextureViewSetLabel(texture_view: *TextureView, label: ?[*:0]const u8) void;
-extern fn wgpuTextureViewReference(texture_view: *TextureView) void;
+extern fn wgpuTextureViewAddRef(texture_view: *TextureView) void;
 extern fn wgpuTextureViewRelease(texture_view: *TextureView) void;
 
 pub const TextureView = opaque {
@@ -164,7 +164,10 @@ pub const TextureView = opaque {
         wgpuTextureViewSetLabel(self, label);
     }
     pub inline fn reference(self: *TextureView) void {
-        wgpuTextureViewReference(self);
+        addRef(self);
+    }
+    pub inline fn addRef(self: *TextureView) void {
+        wgpuTextureViewAddRef(self);
     }
     pub inline fn release(self: *TextureView) void {
         wgpuTextureViewRelease(self);
@@ -249,7 +252,7 @@ pub const TextureProcs = struct {
     pub const GetUsage = *const fn(*Texture) callconv(.C) TextureUsageFlags;
     pub const GetWidth = *const fn(*Texture) callconv(.C) u32;
     pub const SetLabel = *const fn(*Texture, ?[*:0]const u8) callconv(.C) void;
-    pub const Reference = *const fn(*Texture) callconv(.C) void;
+    pub const AddRef = *const fn(*Texture) callconv(.C) void;
     pub const Release = *const fn(*Texture) callconv(.C) void;
 };
 
@@ -264,7 +267,7 @@ extern fn wgpuTextureGetSampleCount(texture: *Texture) u32;
 extern fn wgpuTextureGetUsage(texture: *Texture) TextureUsageFlags;
 extern fn wgpuTextureGetWidth(texture: *Texture) u32;
 extern fn wgpuTextureSetLabel(texture: *Texture, label: ?[*:0]const u8) void;
-extern fn wgpuTextureReference(texture: *Texture) void;
+extern fn wgpuTextureAddRef(texture: *Texture) void;
 extern fn wgpuTextureRelease(texture: *Texture) void;
 
 pub const Texture = opaque {
@@ -302,7 +305,10 @@ pub const Texture = opaque {
         wgpuTextureSetLabel(self, label);
     }
     pub inline fn reference(self: *Texture) void {
-        wgpuTextureReference(self);
+        addRef(self);
+    }
+    pub inline fn addRef(self: *Texture) void {
+        wgpuTextureAddRef(self);
     }
     pub inline fn release(self: *Texture) void {
         wgpuTextureRelease(self);

--- a/src/texture.zig
+++ b/src/texture.zig
@@ -163,9 +163,6 @@ pub const TextureView = opaque {
     pub inline fn setLabel(self: *TextureView, label: ?[*:0]const u8) void {
         wgpuTextureViewSetLabel(self, label);
     }
-    pub inline fn reference(self: *TextureView) void {
-        addRef(self);
-    }
     pub inline fn addRef(self: *TextureView) void {
         wgpuTextureViewAddRef(self);
     }
@@ -303,9 +300,6 @@ pub const Texture = opaque {
     }
     pub inline fn setLabel(self: *Texture, label: ?[*:0]const u8) void {
         wgpuTextureSetLabel(self, label);
-    }
-    pub inline fn reference(self: *Texture) void {
-        addRef(self);
     }
     pub inline fn addRef(self: *Texture) void {
         wgpuTextureAddRef(self);


### PR DESCRIPTION
webgpu-native group thought fit to rename all calls to "*Reference" to "*AddRef" as per this issue: https://github.com/webgpu-native/webgpu-headers/issues/198